### PR TITLE
Mocking Network

### DIFF
--- a/TestingSwift.xcodeproj/project.pbxproj
+++ b/TestingSwift.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		9959C46D25D19943006507BE /* TestDouble.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9959C46C25D19943006507BE /* TestDouble.swift */; };
 		9959C48125D19F5B006507BE /* PurchaseImplementations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9959C48025D19F5B006507BE /* PurchaseImplementations.swift */; };
 		9959C48B25D1A108006507BE /* PurchaseProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9959C48A25D1A108006507BE /* PurchaseProtocol.swift */; };
+		995F508925DAECD100AE2384 /* MockingNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995F508825DAECD100AE2384 /* MockingNetwork.swift */; };
+		995F508F25DAF3BC00AE2384 /* MockingNetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995F508E25DAF3BC00AE2384 /* MockingNetworkTests.swift */; };
 		997CF49A25D6D251004B377A /* DependencyStruct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 997CF49925D6D251004B377A /* DependencyStruct.swift */; };
 		997CF4A525D6DD45004B377A /* Mocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 997CF4A425D6DD45004B377A /* Mocking.swift */; };
 		997CF4B025D6DE4A004B377A /* MockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 997CF4AF25D6DE4A004B377A /* MockTests.swift */; };
@@ -108,6 +110,8 @@
 		9959C46C25D19943006507BE /* TestDouble.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDouble.swift; sourceTree = "<group>"; };
 		9959C48025D19F5B006507BE /* PurchaseImplementations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseImplementations.swift; sourceTree = "<group>"; };
 		9959C48A25D1A108006507BE /* PurchaseProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseProtocol.swift; sourceTree = "<group>"; };
+		995F508825DAECD100AE2384 /* MockingNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockingNetwork.swift; sourceTree = "<group>"; };
+		995F508E25DAF3BC00AE2384 /* MockingNetworkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockingNetworkTests.swift; sourceTree = "<group>"; };
 		997CF49925D6D251004B377A /* DependencyStruct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyStruct.swift; sourceTree = "<group>"; };
 		997CF4A425D6DD45004B377A /* Mocking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mocking.swift; sourceTree = "<group>"; };
 		997CF4AF25D6DE4A004B377A /* MockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTests.swift; sourceTree = "<group>"; };
@@ -374,6 +378,7 @@
 			children = (
 				997CF4A425D6DD45004B377A /* Mocking.swift */,
 				997CF4C125D6F22A004B377A /* PartialMock.swift */,
+				995F508825DAECD100AE2384 /* MockingNetwork.swift */,
 			);
 			path = Mock;
 			sourceTree = "<group>";
@@ -383,6 +388,7 @@
 			children = (
 				997CF4AF25D6DE4A004B377A /* MockTests.swift */,
 				997CF4C725D6F48F004B377A /* PartialMock.swift */,
+				995F508E25DAF3BC00AE2384 /* MockingNetworkTests.swift */,
 			);
 			path = MockTesting;
 			sourceTree = "<group>";
@@ -579,6 +585,7 @@
 				992BB80A25D43725007AD375 /* InjectionClosures.swift in Sources */,
 				995306DC25CB080D006AE71F /* Converter.swift in Sources */,
 				99A3EFEA25D839D2007A60DC /* Preconditions.swift in Sources */,
+				995F508925DAECD100AE2384 /* MockingNetwork.swift in Sources */,
 				992BB82725D451C9007AD375 /* URLOpener.swift in Sources */,
 				99F6FC1E25D2E48A00DBD252 /* Tweet.swift in Sources */,
 				9953F65725CC5B2F00650505 /* House.swift in Sources */,
@@ -602,6 +609,7 @@
 				99A3EFF525D83FDF007A60DC /* Preconditions.swift in Sources */,
 				995306E525CB08A4006AE71F /* ConverterTests.swift in Sources */,
 				9953073825CB2E90006AE71F /* AssertArrayTest.swift in Sources */,
+				995F508F25DAF3BC00AE2384 /* MockingNetworkTests.swift in Sources */,
 				995306BF25CB0050006AE71F /* TestingSwiftTests.swift in Sources */,
 				99531CF725CB59A30054AA05 /* PerformanceTesting.swift in Sources */,
 				99F6FC2E25D2F51700DBD252 /* TweetTests.swift in Sources */,

--- a/TestingSwift.xcodeproj/xcuserdata/danielspady.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/TestingSwift.xcodeproj/xcuserdata/danielspady.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,4 +3,214 @@
    uuid = "26C1D628-214E-4B06-A5E7-05AA76A294A3"
    type = "1"
    version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "2D856540-D652-4040-8469-C0A2F0164D4C"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "TestingSwiftTests/MockTesting/MockingNetworkTests.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "52"
+            endingLineNumber = "52"
+            landmarkName = "testNewsFetchLoadsCorrectURL()"
+            landmarkType = "7">
+            <Locations>
+               <Location
+                  uuid = "2D856540-D652-4040-8469-C0A2F0164D4C - f422b6a35f30e4a0"
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "TestingSwiftTests.MockingNetworkTests.testNewsFetchLoadsCorrectURL() -&gt; ()"
+                  moduleName = "TestingSwiftTests"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Volumes/My%20Passport%20for%20Mac/Repository/TestingSwift/TestingSwiftTests/MockTesting/MockingNetworkTests.swift"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "52"
+                  endingLineNumber = "52"
+                  offsetFromSymbolStart = "695">
+               </Location>
+               <Location
+                  uuid = "2D856540-D652-4040-8469-C0A2F0164D4C - afffeed4281bb6d3"
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "closure #1 () -&gt; () in TestingSwiftTests.MockingNetworkTests.testNewsFetchLoadsCorrectURL() -&gt; ()"
+                  moduleName = "TestingSwiftTests"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Volumes/My%20Passport%20for%20Mac/Repository/TestingSwift/TestingSwiftTests/MockTesting/MockingNetworkTests.swift"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "53"
+                  endingLineNumber = "53"
+                  offsetFromSymbolStart = "101">
+               </Location>
+            </Locations>
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "15CC5291-2901-4795-B6E3-8FC6C905B1BC"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "AsynchronousTests/AsynchronousTests.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "31"
+            endingLineNumber = "31"
+            landmarkName = "testPrimesUpTo100ShouldBe25()"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "5A4FEAED-DD3C-40EC-993A-4D956DE09111"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "TestingSwiftTests/MockTesting/MockingNetworkTests.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "38"
+            endingLineNumber = "38"
+            landmarkName = "dataTask(with:completionHandler:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "C32532EA-62A7-41ED-899C-E92E5DCF6FFC"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "TestingSwiftTests/MockTesting/MockingNetworkTests.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "58"
+            endingLineNumber = "58"
+            landmarkName = "testNewsFetchLoadsCorrectURL()"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "18908D51-99D2-4EA6-AE61-7548F7BD67DA"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "TestingSwift/Mock/MockingNetwork.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "60"
+            endingLineNumber = "60"
+            landmarkName = "fetch(using:completionHandler:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "F4E09CA2-F9BC-4C59-85B8-5E7DC046F514"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "TestingSwift/Mock/MockingNetwork.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "63"
+            endingLineNumber = "63"
+            landmarkName = "fetch(using:completionHandler:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "D191C4E8-D424-49B2-93B8-DB3861070172"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "TestingSwift/Mock/MockingNetwork.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "68"
+            endingLineNumber = "68"
+            landmarkName = "fetch(using:completionHandler:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "AF6A63D4-60BC-43B9-BDDF-5B81F49ABC5A"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "TestingSwift/Mock/MockingNetwork.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "57"
+            endingLineNumber = "57"
+            landmarkName = "fetch(using:completionHandler:)"
+            landmarkType = "7">
+            <Locations>
+               <Location
+                  uuid = "AF6A63D4-60BC-43B9-BDDF-5B81F49ABC5A - 24658687c887de86"
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "TestingSwift.News.fetch(using: TestingSwift.URLSessionProtocol, completionHandler: () -&gt; ()) -&gt; ()"
+                  moduleName = "TestingSwift"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Volumes/My%20Passport%20for%20Mac/Repository/TestingSwift/TestingSwift/Mock/MockingNetwork.swift"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "57"
+                  endingLineNumber = "57"
+                  offsetFromSymbolStart = "130">
+               </Location>
+               <Location
+                  uuid = "AF6A63D4-60BC-43B9-BDDF-5B81F49ABC5A - c7a1e7e83d85fd0d"
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "closure #1 (Swift.Optional&lt;Foundation.Data&gt;, Swift.Optional&lt;__C.NSURLResponse&gt;, Swift.Optional&lt;Swift.Error&gt;) -&gt; () in TestingSwift.News.fetch(using: TestingSwift.URLSessionProtocol, completionHandler: () -&gt; ()) -&gt; ()"
+                  moduleName = "TestingSwift"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Volumes/My%20Passport%20for%20Mac/Repository/TestingSwift/TestingSwift/Mock/MockingNetwork.swift"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "59"
+                  endingLineNumber = "59"
+                  offsetFromSymbolStart = "293">
+               </Location>
+            </Locations>
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "FE8DF4C9-6803-451D-9449-766E18B7B4E5"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "TestingSwift/Mock/MockingNetwork.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "59"
+            endingLineNumber = "59"
+            landmarkName = "fetch(using:completionHandler:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
 </Bucket>

--- a/TestingSwift/Mock/MockingNetwork.swift
+++ b/TestingSwift/Mock/MockingNetwork.swift
@@ -1,0 +1,81 @@
+//
+//  MockingNetwork.swift
+//  TestingSwift
+//
+//  Created by Daniel Spady on 2021-02-15.
+//
+
+import Foundation
+
+// Networking is where mocking really comes into its own, because it allows us to run simulated network requests
+
+class News {
+    var url: URL
+    var stories = ""
+    
+    init(url: URL) {
+        self.url = url
+    }
+    
+    // Testing the below class requires we remove the dependency of URLSession.shared
+
+    func fetchWithURLSessionDependency(completionHandler: @escaping () -> Void) {
+        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            
+            if let data = data {
+                self.stories = String(decoding: data, as: UTF8.self)
+            }
+            
+            completionHandler()
+            
+        }
+        
+        task.resume()
+    }
+    
+    // Inject URLSession Dependency
+    
+    func fetchWithDependencyInjection(using session: URLSession = .shared, completionHandler: @escaping () -> Void) {
+        
+        let task = session.dataTask(with: url) { data, response, error in
+            
+            if let data = data {
+                self.stories = String(decoding: data, as: UTF8.self)
+            }
+            
+            completionHandler()
+            
+        }
+        
+        task.resume()
+    }
+    
+    // Inject URLSession Protocol
+    
+    func fetch(using session: URLSessionProtocol = URLSession.shared, completionHandler: @escaping () -> Void ) {
+        
+        let task = session.dataTask(with: url) { (data, response, error) in
+            
+            if let data = data {
+                self.stories = String(decoding: data, as: UTF8.self)
+            }
+            
+            completionHandler()
+        }
+        
+        completionHandler()
+        
+        task.resume()
+    }
+    
+}
+
+// Create a protocol that lets us mock URLSession
+
+// Needs us to call dataTask(with:), passing in a completion handler
+
+protocol URLSessionProtocol {
+    func dataTask(with url: URL, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
+}
+
+extension URLSession: URLSessionProtocol { }

--- a/TestingSwiftTests/MockTesting/MockingNetworkTests.swift
+++ b/TestingSwiftTests/MockTesting/MockingNetworkTests.swift
@@ -1,0 +1,68 @@
+//
+//  MockingNetworkTests.swift
+//  TestingSwiftTests
+//
+//  Created by Daniel Spady on 2021-02-15.
+//
+
+import XCTest
+@testable import TestingSwift
+
+class MockingNetworkTests: XCTestCase {
+    
+    // 1. What was the URL that was requested?
+    
+    // Requires creating a new concrete implementation of the URLSessionProtocol, which will store the URL that was requested.
+    
+    // When dataTask() method is called we'll stash away the URL
+    
+    // Send back an empty data task to satisfy the URL, call completion handler immediately
+    
+    // Foundation doesn't let us use URLSessionDataTask directly, because it's technically an abstract class.
+    
+    // Create a mock version that just has an empty resume() method
+    
+    // Dummy Tests: Doesn't do anything except satisfy the need for dataTask() to return something
+    
+    class DataTaskMock: URLSessionDataTask {
+        override func resume() { }
+    }
+    
+    // Use defer so that it automatically calls its completion handler with nil values
+    
+    class URLSessionMock: URLSessionProtocol {
+        
+        var lastUrl: URL?
+        
+        func dataTask(with url: URL, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+            lastUrl = url
+            return DataTaskMock()
+        }
+    }
+    
+    func testNewsFetchLoadsCorrectURL() {
+        
+        // Given
+        let url = URL(string: "https://www.apple.com/newsroom/rss-feed.rss")!
+        let news = News(url: url)
+        let session = URLSessionMock()
+        let expectation = XCTestExpectation(description: "Downloading news stories.")
+        
+        // When
+        news.fetch(using: session) {
+            XCTAssertEqual(URL(string: "https://www.apple.com/newsroom/rss-feed.rss"), session.lastUrl)
+            expectation.fulfill()
+        }
+        
+        // Then
+        wait(for: [expectation], timeout: 10)
+    }
+    
+    // 2. Was a network request actually started?
+    
+    // 3. Did the requestcome back with certain data?
+    
+    // 4. Did the request come back with a specific error
+    
+    
+}


### PR DESCRIPTION
Create News Class that has examples of fetch methods that has a dependency, uses . dependency injection, and injects a protocol dependency.
Create a URL Session Protocol, and extend URLSession.
Create a Dummy Test Mock that subclasses URLSessionDataTask
Unit test News class fetch method with URLSession Mock.

TODO:

Debug unit test with completion handle
Refactor DataTaskMock because of init Depreciation